### PR TITLE
Compatibility with Thunderbird 128

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
     "applications": {
         "gecko": {
             "id": "autoMarkFolderRead.silvester@addons.thunderbird.net",
-            "strict_min_version": "128.0"
+            "strict_min_version": "122.0"
         }
     },
 	"background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,14 +3,14 @@
     "name": "__MSG_extensionName__",
 	"short_name": "__MSG_extensionShortName__",
     "description": "__MSG_extensionDescription__",
-    "version": "1.5",
+    "version": "1.6",
     "author": "Silvester",
     "default_locale": "en",
 	"homepage_url": "https://github.com/thirdinsight/AutoMarkFolderRead",
     "applications": {
         "gecko": {
             "id": "autoMarkFolderRead.silvester@addons.thunderbird.net",
-            "strict_min_version": "91.0"
+            "strict_min_version": "128.0"
         }
     },
 	"background": {
@@ -22,6 +22,7 @@
 	"permissions": [
 		"accountsRead",
 		"messagesRead",
+		"messagesUpdate",
 		"storage"
 	],
 	"icons": {


### PR DESCRIPTION
Thunderbird 128 introduced a rare backward incompatibility in its WebExtension API: The method `messages.update()` is now protected by the `messagesUpdate` permission.